### PR TITLE
workaround username 2.0 not working with node 0.12

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var debug = require('debug')('sync-disk-cache');
 var zlib = require('zlib');
 var heimdall =  require('heimdalljs');
 var os = require('os');
-var username = require('username').sync();
+var username = require('child_process').execSync('whoami').toString().trim();
 var tmpdir = path.join(os.tmpdir(), username);
 var mode = {
   mode: parseInt('0777', 8)

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "debug": "^2.1.3",
     "heimdalljs": "^0.2.3",
     "mkdirp": "^0.5.0",
-    "rimraf": "^2.2.8",
-    "username": "^2.3.0"
+    "rimraf": "^2.2.8"
   },
   "devDependencies": {
     "istanbul": "^0.3.6",

--- a/test.js
+++ b/test.js
@@ -24,8 +24,9 @@ describe('cache', function() {
 
     var descriptiveName = 'if-you-need-to-delete-this-open-an-issue-sync-disk-cache';
     var defaultKey = 'default-disk-cache';
+    var username = require('child_process').execSync('whoami').toString().trim();
 
-    should(cache.root).equal(path.join(tmpdir, require('username').sync(), descriptiveName, defaultKey));
+    should(cache.root).equal(path.join(tmpdir, username, descriptiveName, defaultKey));
   });
 
   it('pathFor', function() {


### PR DESCRIPTION
NOTE: Please upgrade to a supported version of node: https://github.com/nodejs/LTS v0.12 is no longer covered by Node’s own Long-Term Support Working Group